### PR TITLE
check connections are valid before applying them

### DIFF
--- a/src/connections.jl
+++ b/src/connections.jl
@@ -180,3 +180,28 @@ function runconnection!(merInt::AbstractMermaidIntegrator, conn::AbstractConnect
         end
     end
 end
+
+function checkconnection(conn::AbstractConnector, merInt::AbstractMermaidIntegrator)
+    # Check if all inputs are earlier in time than (or equal to) the time of all outputs
+    max_input_time = -Inf
+    for input in conn.inputs
+        conn_tmp = ConnectedVariable(input.component, "#time", nothing, nothing)
+        time_tmp = prevfloat(getstate(merInt, conn_tmp))
+        # Apply timescales
+        time_tmp *= prevfloat(merInt.timescales[findfirst(i -> name(i) == input.component, merInt.integrators)])
+        if time_tmp > max_input_time
+            max_input_time = time_tmp
+        end
+    end
+    min_output_time = Inf
+    for output in conn.outputs
+        conn_tmp = ConnectedVariable(output.component, "#time", nothing, nothing)
+        time_tmp = nextfloat(getstate(merInt, conn_tmp))
+        # Apply timescales
+        time_tmp *= nextfloat(merInt.timescales[findfirst(i -> name(i) == output.component, merInt.integrators)])
+        if time_tmp < min_output_time
+            min_output_time = time_tmp
+        end
+    end
+    return max_input_time <= min_output_time
+end

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -30,7 +30,7 @@ function CommonSolve.step!(merInt::MermaidIntegrator, ::MinimumTimeStepper)
     end
     # Step the integrator
     for (int, timescale) in zip(merInt.integrators, merInt.timescales)
-        if (gettime(int) + timestep(int)) * timescale <= nextfloat(merInt.currtime)
+        if (gettime(int) + timestep(int)) * timescale <= nextfloat(merInt.currtime, 3)
             t_before = gettime(int)
             # Step the integrator
             step!(int)
@@ -38,8 +38,9 @@ function CommonSolve.step!(merInt::MermaidIntegrator, ::MinimumTimeStepper)
                 error("Component $(name(int)) failed to advance: time did not move forward from $t_before.")
             end
             # Force time synchronization after stepping to avoid floating point issues.
-            # Especially important for handling multiple timescales.
-            if gettime(int) * timescale == nextfloat(merInt.currtime)
+            # Especially important for handling multiple timescales to avoid errors stacking.
+            if gettime(int) * timescale != merInt.currtime
+                @assert prevfloat(merInt.currtime, 3) <= gettime(int) * timescale <= nextfloat(merInt.currtime, 3) "Floating point rounding is larger than expected. Please report this bug. $((gettime(int), timescale, merInt.currtime))"
                 settime!(int, merInt.currtime / timescale)
             end
         end

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -24,7 +24,9 @@ function CommonSolve.step!(merInt::MermaidIntegrator, ::MinimumTimeStepper)
     merInt.currtime = min_t
     # Apply connections
     for conn in merInt.connectors
-        runconnection!(merInt, conn)
+        if checkconnection(conn, merInt)
+            runconnection!(merInt, conn)
+        end
     end
     # Step the integrator
     for (int, timescale) in zip(merInt.integrators, merInt.timescales)


### PR DESCRIPTION
we need to do some funky nextfloat and prevfloat to avoid issues with timescales this solution isn't perfect and inaccuracies can still stack up in #time by repeatedly adding a timestep that rounds down when converted to float (or up tbh), but it does perfectly handle the inaccuracies due to multiplying the timescale